### PR TITLE
Implement logout

### DIFF
--- a/token-support-idporten/README.md
+++ b/token-support-idporten/README.md
@@ -14,9 +14,10 @@ spec:
 
 For å kunne autentisere et endepunkt må man først installere autentikatoren.
 
-Her er det 4 variabler:
+Her er det 5 variabler:
 
 `tokenCookieName`: (Required) Navn på token-cookien som settes i browser etter bruker har logget inn.
+`postLogoutRedirectUri`: (Required) Bestemmer hvor bruker sendes etter de har logget ut. Denne må samsvare med nais-yaml.
 `postLoginRedirectUri`: (Optional) Url der bruker havner etter login dersom vi ikke finner en "redirect_uri" cookie. Default ""
 `setAsDefault`: (Optional) Setter denne autentikatoren som default. Default 'false'
 `secureCookie`: (Optional) Setter token-cookie som secure, slik at den kun sendes med https-kall. Default 'true'
@@ -28,6 +29,7 @@ fun Application.mainModule() {
 
     installIdPortenAuth {
         tokenCookieName = "user_id_token"
+        postLogoutRedirectUri = "https://www.nav.no"
         postLoginRedirectUri = '/post/login'
         setAsDefault = false
         secureCookie = true
@@ -42,6 +44,7 @@ fun Application.mainModule() {
 
     installIdPortenAuth {
         tokenCookieName = "user_id_token"
+        postLogoutRedirectUri = "https://www.nav.no"
         postLoginRedirectUri = '/post/login'
         setAsDefault = false
         secureCookie = true
@@ -64,6 +67,7 @@ fun Application.mainModule() {
 
     installIdPortenAuth {
         tokenCookieName = "user_id_token"
+        postLogoutRedirectUri = "https://www.nav.no"
         setAsDefault = true
     }
     

--- a/token-support-idporten/src/main/kotlin/no/nav/tms/token/support/idporten/authentication/OauthServerConfigurationMetadata.kt
+++ b/token-support-idporten/src/main/kotlin/no/nav/tms/token/support/idporten/authentication/OauthServerConfigurationMetadata.kt
@@ -9,5 +9,6 @@ internal data class OauthServerConfigurationMetadata(
         @SerialName("issuer") val issuer: String,
         @SerialName("token_endpoint") val tokenEndpoint: String,
         @SerialName("jwks_uri") val jwksUri: String,
-        @SerialName("authorization_endpoint") var authorizationEndpoint: String = ""
+        @SerialName("authorization_endpoint") var authorizationEndpoint: String = "",
+        @SerialName("end_session_endpoint") var logoutEndpoint: String = "",
 )

--- a/token-support-idporten/src/main/kotlin/no/nav/tms/token/support/idporten/authentication/config/Environment.kt
+++ b/token-support-idporten/src/main/kotlin/no/nav/tms/token/support/idporten/authentication/config/Environment.kt
@@ -4,7 +4,7 @@ internal class Environment (
         val idportenWellKnownUrl: String = getIdportenEnvVar("IDPORTEN_WELL_KNOWN_URL"),
         val idportenClientId: String = getIdportenEnvVar("IDPORTEN_CLIENT_ID"),
         val idportenClientJwk: String = getIdportenEnvVar("IDPORTEN_CLIENT_JWK"),
-        val idportenRedirectUri: String = getIdportenEnvVar("IDPORTEN_REDIRECT_URI"),
+        val idportenRedirectUri: String = getIdportenEnvVar("IDPORTEN_REDIRECT_URI")
 )
 
 private fun getIdportenEnvVar(varName: String): String {

--- a/token-support-idporten/src/main/kotlin/no/nav/tms/token/support/idporten/authentication/config/RuntimeContext.kt
+++ b/token-support-idporten/src/main/kotlin/no/nav/tms/token/support/idporten/authentication/config/RuntimeContext.kt
@@ -16,7 +16,8 @@ internal class RuntimeContext(
         val tokenCookieName: String,
         val contextPath: String,
         val postLoginRedirectUri: String,
-        val secureCookie: Boolean
+        val secureCookie: Boolean,
+        val postLogoutRedirectUri: String
 ) {
     val environment = Environment()
 

--- a/token-support-idporten/src/main/kotlin/no/nav/tms/token/support/idporten/authentication/logout/Logout.kt
+++ b/token-support-idporten/src/main/kotlin/no/nav/tms/token/support/idporten/authentication/logout/Logout.kt
@@ -1,0 +1,5 @@
+package no.nav.tms.token.support.idporten.authentication.logout
+
+internal object LogoutAuthenticator {
+    const val name = "tms_token_support_logout"
+}

--- a/token-support-idporten/src/main/kotlin/no/nav/tms/token/support/idporten/authentication/logout/idTokenLogout.kt
+++ b/token-support-idporten/src/main/kotlin/no/nav/tms/token/support/idporten/authentication/logout/idTokenLogout.kt
@@ -1,0 +1,43 @@
+package no.nav.tms.token.support.idporten.authentication.logout
+
+import com.auth0.jwt.JWT
+import io.ktor.application.*
+import io.ktor.auth.*
+import no.nav.tms.token.support.idporten.authentication.IdTokenPrincipal
+import org.slf4j.LoggerFactory
+
+private val log = LoggerFactory.getLogger(IdTokenAuthenticationProvider::class.java)
+
+internal fun Authentication.Configuration.idTokenLogout(authenticatorName: String?, configBuilder: () -> LogoutConfig) {
+
+    val config = configBuilder()
+
+    val provider = IdTokenAuthenticationProvider.build(authenticatorName)
+
+    provider.pipeline.intercept(AuthenticationPipeline.RequestAuthentication) { context ->
+        val idToken = call.request.cookies[config.tokenCookieName]
+        if (idToken != null) {
+            try {
+                val decodedJWT = JWT.decode(idToken)
+                context.principal(IdTokenPrincipal(decodedJWT))
+            } catch (e: Throwable) {
+                val message = e.message ?: e.javaClass.simpleName
+                log.debug("Token verification failed during logout: {}", message)
+            }
+        } else {
+            log.debug("Couldn't find cookie ${config.tokenCookieName} during logout.")
+        }
+    }
+    register(provider)
+}
+
+internal class LogoutConfig(val tokenCookieName: String)
+
+private class IdTokenAuthenticationProvider constructor(config: Configuration) : AuthenticationProvider(config) {
+
+    class Configuration(name: String?) : AuthenticationProvider.Configuration(name)
+
+    companion object {
+        fun build(name: String?) = IdTokenAuthenticationProvider(Configuration(name))
+    }
+}

--- a/token-support-idporten/src/main/kotlin/no/nav/tms/token/support/idporten/authentication/logout/logoutApi.kt
+++ b/token-support-idporten/src/main/kotlin/no/nav/tms/token/support/idporten/authentication/logout/logoutApi.kt
@@ -26,16 +26,15 @@ internal fun Routing.logoutApi(context: RuntimeContext) {
         }
     }
 
-    // This endpoint is intended to be called by idporten, and will invalidate idtokens issued for a specific session.
-    // Not currently implemented due to concerns with state handling across different pods.
+    // Calls to this endpoint should be initiated by ID-porten through the user, after the user has signed out elsewhere
     get("/oauth2/logout") {
-        call.respond(HttpStatusCode.OK)
+        call.invalidateCookie(context.tokenCookieName, context.contextPath)
+        call.respondRedirect(context.postLogoutRedirectUri)
     }
 }
 
 private fun ApplicationCall.invalidateCookie(cookieName: String, contextPath: String) {
     response.cookies.appendExpired(cookieName, path = "/$contextPath")
-
 }
 
 private suspend fun ApplicationCall.redirectToSingleSignout(idToken: String, signoutUrl: String, postLogoutUrl: String) {

--- a/token-support-idporten/src/main/kotlin/no/nav/tms/token/support/idporten/authentication/logout/logoutApi.kt
+++ b/token-support-idporten/src/main/kotlin/no/nav/tms/token/support/idporten/authentication/logout/logoutApi.kt
@@ -9,7 +9,6 @@ import io.ktor.routing.*
 import io.ktor.util.date.*
 import no.nav.tms.token.support.idporten.authentication.IdTokenPrincipal
 import no.nav.tms.token.support.idporten.authentication.config.RuntimeContext
-import org.slf4j.LoggerFactory
 import java.net.URI
 
 internal fun Routing.logoutApi(context: RuntimeContext) {

--- a/token-support-idporten/src/main/kotlin/no/nav/tms/token/support/idporten/authentication/logout/logoutApi.kt
+++ b/token-support-idporten/src/main/kotlin/no/nav/tms/token/support/idporten/authentication/logout/logoutApi.kt
@@ -31,7 +31,7 @@ internal fun Routing.logoutApi(context: RuntimeContext) {
 
     // Calls to this endpoint should be initiated by ID-porten through the user, after the user has signed out elsewhere
     get("/oauth2/logout") {
-        call.invalidateCookieForExternalLogout(context.tokenCookieName, context.contextPath)
+        call.invalidateCookieForExternalLogout(context.tokenCookieName, context.contextPath, context.secureCookie)
         call.respond(OK)
     }
 }
@@ -53,12 +53,9 @@ private suspend fun ApplicationCall.redirectToSingleLogout(idToken: String, sign
     respondRedirect(redirectUrl)
 }
 
-private fun ApplicationCall.invalidateCookieForExternalLogout(cookieName: String, contextPath: String) {
-    val scheme = request.local.scheme
+private fun ApplicationCall.invalidateCookieForExternalLogout(cookieName: String, contextPath: String, secure: Boolean) {
 
-    LoggerFactory.getLogger("Logout").info(scheme)
-
-    if (scheme == "https") {
+    if (secure) {
         response.cookies.appendExpiredCrossSite(cookieName, contextPath)
     } else {
         response.cookies.appendExpired(cookieName, path = "/$contextPath")

--- a/token-support-idporten/src/main/kotlin/no/nav/tms/token/support/idporten/authentication/logout/logoutApi.kt
+++ b/token-support-idporten/src/main/kotlin/no/nav/tms/token/support/idporten/authentication/logout/logoutApi.kt
@@ -1,0 +1,52 @@
+package no.nav.tms.token.support.idporten.authentication.logout
+
+import io.ktor.application.*
+import io.ktor.auth.*
+import io.ktor.http.*
+import io.ktor.response.*
+import io.ktor.routing.*
+import no.nav.tms.token.support.idporten.authentication.IdTokenPrincipal
+import no.nav.tms.token.support.idporten.authentication.config.RuntimeContext
+import java.net.URI
+
+internal fun Routing.logoutApi(context: RuntimeContext) {
+
+    authenticate(LogoutAuthenticator.name) {
+        // Calling this endpoint with a bearer token will send a redirect to idporten to trigger single-logout
+        get("/logout") {
+            val principal = call.principal<IdTokenPrincipal>()
+
+            call.invalidateCookie(context.tokenCookieName, context.contextPath)
+
+            if (principal == null) {
+                call.respondRedirect(context.postLogoutRedirectUri)
+            } else {
+                call.redirectToSingleSignout(principal.decodedJWT.token, context.metadata.logoutEndpoint, context.postLogoutRedirectUri)
+            }
+        }
+    }
+
+    // This endpoint is intended to be called by idporten, and will invalidate idtokens issued for a specific session.
+    // Not currently implemented due to concerns with state handling across different pods.
+    get("/oauth2/logout") {
+        call.respond(HttpStatusCode.OK)
+    }
+}
+
+private fun ApplicationCall.invalidateCookie(cookieName: String, contextPath: String) {
+    response.cookies.appendExpired(cookieName, path = "/$contextPath")
+
+}
+
+private suspend fun ApplicationCall.redirectToSingleSignout(idToken: String, signoutUrl: String, postLogoutUrl: String) {
+    val urlBuilder = URLBuilder()
+    urlBuilder.takeFrom(URI(signoutUrl))
+    urlBuilder.parameters.apply {
+        append("id_token_hint", idToken)
+        append("post_logout_redirect_uri", postLogoutUrl)
+    }
+
+    val redirectUrl = urlBuilder.buildString()
+
+    respondRedirect(redirectUrl)
+}

--- a/token-support-idporten/src/main/kotlin/no/nav/tms/token/support/idporten/config.kt
+++ b/token-support-idporten/src/main/kotlin/no/nav/tms/token/support/idporten/config.kt
@@ -62,13 +62,15 @@ fun Application.installIdPortenAuth(configure: IdportenAuthenticationConfig.() -
             urlProvider = { runtimeContext.environment.idportenRedirectUri }
         }
 
+        // Register endpoints for performing logout. This includes an endpoint which initiates single logout through
+        // ID-porten, and one which handles logout initiated elsewhere
         idTokenLogout(LogoutAuthenticator.name) {
             LogoutConfig(tokenCookieName = cookieName)
         }
 
     }
 
-    // Register endpoints 'oauth2/login' and 'oath2/callback'
+    // Register endpoints 'oauth2/login',  'oath2/callback', '/logout', and /oauth2/logout
     routing {
         loginApi(runtimeContext)
         logoutApi(runtimeContext)

--- a/token-support-idporten/src/main/kotlin/no/nav/tms/token/support/idporten/config.kt
+++ b/token-support-idporten/src/main/kotlin/no/nav/tms/token/support/idporten/config.kt
@@ -11,6 +11,10 @@ import no.nav.tms.token.support.idporten.authentication.config.Idporten
 import no.nav.tms.token.support.idporten.authentication.config.RuntimeContext
 import no.nav.tms.token.support.idporten.authentication.idToken
 import no.nav.tms.token.support.idporten.authentication.loginApi
+import no.nav.tms.token.support.idporten.authentication.logout.LogoutAuthenticator
+import no.nav.tms.token.support.idporten.authentication.logout.LogoutConfig
+import no.nav.tms.token.support.idporten.authentication.logout.idTokenLogout
+import no.nav.tms.token.support.idporten.authentication.logout.logoutApi
 
 
 // This method is responsible for wiring up all the necessary endpoints and registering the authenticators.
@@ -19,16 +23,20 @@ fun Application.installIdPortenAuth(configure: IdportenAuthenticationConfig.() -
     val config = IdportenAuthenticationConfig().apply(configure)
     val contextPath = environment.rootPath
     val cookieName = config.tokenCookieName
+    val postLogoutRedirectUri = config.postLogoutRedirectUri
 
     val authenticatorName = getAuthenticatorName(config.setAsDefault)
 
     require(cookieName.isNotBlank()) { "Navn på token-cookie må spesifiseres." }
 
+    require(postLogoutRedirectUri.isNotBlank()) { "Post-logout uri må spesifiseres. Pass på at dette matcher nais yaml." }
+
     val runtimeContext = RuntimeContext(
             tokenCookieName = cookieName,
             contextPath = contextPath,
             postLoginRedirectUri = config.postLoginRedirectUri,
-            secureCookie = config.secureCookie
+            secureCookie = config.secureCookie,
+            postLogoutRedirectUri = postLogoutRedirectUri
     )
 
     installXForwardedHeaderSupportIfMissing()
@@ -54,11 +62,16 @@ fun Application.installIdPortenAuth(configure: IdportenAuthenticationConfig.() -
             urlProvider = { runtimeContext.environment.idportenRedirectUri }
         }
 
+        idTokenLogout(LogoutAuthenticator.name) {
+            LogoutConfig(tokenCookieName = cookieName)
+        }
+
     }
 
     // Register endpoints 'oauth2/login' and 'oath2/callback'
     routing {
         loginApi(runtimeContext)
+        logoutApi(runtimeContext)
     }
 
 }
@@ -83,6 +96,7 @@ class IdportenAuthenticationConfig {
     var postLoginRedirectUri: String = ""
     var setAsDefault: Boolean = false
     var secureCookie: Boolean = true
+    var postLogoutRedirectUri: String = ""
 }
 
 // Name of token authenticator. See README for example of use


### PR DESCRIPTION
Biblioteket legger nå til to nye endepunkt `/logout` og `/oauth2/logout`.

`/logout` er ment å kalles fra bruker selv via frontend. Denne initialiserer single logout hos ID-porten, slik at bruker logges fullstendig ut overalt.

`/oauth2/logout` er ment å kalles i bakgrunnen i brukers browser etter logout har vært initialisert hos en annen ID-porten-integrert tjeneste. Frontender o.l. bør ikke bruke dette endepunktet.


For å se hvordan dette fungerer i praksis, kan du logge inn i både [mine-saker-api](https://mine-saker-api.dev.nav.no/person/mine-saker-api/sakstemaer) og [test-dummy](https://tms-tokenx-test-dummy.dev.nav.no/front/sikret), og så kalle `/logout` på én av tjenestene. Hvis du åpner utviklertjenester og følger med på nettverkskall, vil du kunne se et kall til `/oauth2/logout` hos den andre tjenesten.
