### PR TITLE
Login path

### DIFF
--- a/token-support-idporten/README.md
+++ b/token-support-idporten/README.md
@@ -20,7 +20,9 @@ Her er det 5 variabler:
 `postLogoutRedirectUri`: (Required) Bestemmer hvor bruker sendes etter de har logget ut. Denne må samsvare med nais-yaml.
 `postLoginRedirectUri`: (Optional) Url der bruker havner etter login dersom vi ikke finner en "redirect_uri" cookie. Default ""
 `setAsDefault`: (Optional) Setter denne autentikatoren som default. Default 'false'
-`secureCookie`: (Optional) Setter token-cookie som secure, slik at den kun sendes med https-kall. Default 'true'
+`secureCookie`: (Optional) Setter token-cookie som secure, slik at den kun sendes med https-kall. Bør kun skrus av ved lokal kjøring. Default 'true'
+`alwaysRedirectToLogin`: (Optional) Bestemmer om beskyttede endepunkt kan sende bruker til ID-porten, eller om de kun svarer med status 401. Default 'false'
+`securityLevel`: (Optional) Setter minimum sikkerhetsnivå for alle innlogginger. Default 'NOT_SPECIFIED' 
  
 Eksempel på konfigurasjon:
 
@@ -33,6 +35,8 @@ fun Application.mainModule() {
         postLoginRedirectUri = '/post/login'
         setAsDefault = false
         secureCookie = true
+        alwaysRedirectToLogin = false
+        securityLevel = SecurityLevel.LEVEL_3
     }
 }
 ```
@@ -48,6 +52,8 @@ fun Application.mainModule() {
         postLoginRedirectUri = '/post/login'
         setAsDefault = false
         secureCookie = true
+        alwaysRedirectToLogin = false
+        securityLevel = SecurityLevel.LEVEL_3
     }
     
     routing {
@@ -60,7 +66,7 @@ fun Application.mainModule() {
 }
 ```
 
-Typisk eksempel på bruk i miljø og dette er default authenticator:
+Typisk eksempel på bruk i miljø i et fagområde som krever nivå 4 og dette er default authenticator:
 
 ```kotlin
 fun Application.mainModule() {
@@ -69,6 +75,7 @@ fun Application.mainModule() {
         tokenCookieName = "user_id_token"
         postLogoutRedirectUri = "https://www.nav.no"
         setAsDefault = true
+        securityLevel = SecurityLevel.LEVEL_4
     }
     
     routing {
@@ -83,6 +90,30 @@ fun Application.mainModule() {
 
 Etter bruker her har logget inn i idporten vil den få et jwt token lagret i cookie 'user_id_token'. 
 Denne cookien er scopet til domene og rootpath for appen.
+
+## Redirect vs http status 401
+
+---
+
+Når `securityLevel` er satt til 'false', vil beskyttede endepunkt svare med http-status 401 dersom bruker ikke
+har et gyldig ID-token. For at bruker skal bli sendt til ID-porten må bruker først innom endepunktet `/login`. 
+Dette endepunktet tillater å overstyre endelig redirect etter login med parameteren `redirect_uri`. Biblioteket 
+tilbyr også et endepunkt `/login/statsus` som viser om bruker er logget inn eller ikke, og evt på hvilket nivå.
+
+Eksempel oppsett med js-frontend 'app-1' og ktor backend 'app-2' der dette biblioteket er installert. 
+
+1. app-1 kaller `<app-2>/login/status` hos app-2 og ser at bruker ikke er logget inn.
+
+2. app-1 sender bruker til `<app-2>/login?redirect_uri=<app-1>`
+
+3. Bruker blir sendt til ID-porten, logger inn, og blir sendt tilbake til app-2
+
+4. app-2 sender bruker tilbake til app-1
+
+---
+
+Når `securityLevel` er satt til 'true', vil alle beskyttede endepunk kunne svare med en redirect til ID-porten
+dersom bruker ikke har et gyldig id-token. Dette passer best når biblioteket er installert på en frontend ktor-app.
 
 ## IdportenUser
 

--- a/token-support-idporten/src/main/kotlin/no/nav/tms/token/support/idporten/authentication/AuthConfiguration.kt
+++ b/token-support-idporten/src/main/kotlin/no/nav/tms/token/support/idporten/authentication/AuthConfiguration.kt
@@ -7,5 +7,6 @@ internal class AuthConfiguration(
         val tokenCookieName: String,
         val jwkProvider: JwkProvider,
         val clientId: String,
-        val issuer: String
+        val issuer: String,
+        val shouldRedirect: Boolean
 )

--- a/token-support-idporten/src/main/kotlin/no/nav/tms/token/support/idporten/authentication/LoginStatus.kt
+++ b/token-support-idporten/src/main/kotlin/no/nav/tms/token/support/idporten/authentication/LoginStatus.kt
@@ -1,0 +1,14 @@
+package no.nav.tms.token.support.idporten.authentication
+
+import kotlinx.serialization.Serializable
+
+@Serializable
+internal data class LoginStatus(
+    val authenticated: Boolean,
+    val level: Int?
+) {
+    companion object {
+        fun unAuthenticated() = LoginStatus(false, null)
+        fun authenticated(level: Int) = LoginStatus(true, level)
+    }
+}

--- a/token-support-idporten/src/main/kotlin/no/nav/tms/token/support/idporten/authentication/TokenVerifier.kt
+++ b/token-support-idporten/src/main/kotlin/no/nav/tms/token/support/idporten/authentication/TokenVerifier.kt
@@ -1,0 +1,33 @@
+package no.nav.tms.token.support.idporten.authentication
+
+import com.auth0.jwk.Jwk
+import com.auth0.jwk.JwkProvider
+import com.auth0.jwt.JWT
+import com.auth0.jwt.algorithms.Algorithm
+import com.auth0.jwt.interfaces.DecodedJWT
+import com.auth0.jwt.interfaces.JWTVerifier
+import java.security.interfaces.RSAPublicKey
+
+internal class TokenVerifier(
+        private val jwkProvider: JwkProvider,
+        private val clientId: String,
+        private val issuer: String
+) {
+
+    fun verify(accessToken: String): DecodedJWT {
+        return JWT.decode(accessToken).keyId
+                .let { kid -> jwkProvider.get(kid) }
+                .run { idTokenVerifier(clientId, issuer) }
+                .run { verify(accessToken) }
+    }
+
+    private fun Jwk.idTokenVerifier(clientId: String, issuer: String): JWTVerifier =
+            JWT.require(this.RSA256())
+                    .withAudience(clientId)
+                    .withIssuer(issuer)
+                    .build()
+
+    private fun Jwk.RSA256() = Algorithm.RSA256(publicKey as RSAPublicKey, null)
+}
+
+

--- a/token-support-idporten/src/main/kotlin/no/nav/tms/token/support/idporten/authentication/loginApi.kt
+++ b/token-support-idporten/src/main/kotlin/no/nav/tms/token/support/idporten/authentication/loginApi.kt
@@ -1,57 +1,65 @@
 package no.nav.tms.token.support.idporten.authentication
 
-import com.auth0.jwt.JWT
 import com.auth0.jwt.interfaces.DecodedJWT
 import io.ktor.application.*
-import io.ktor.auth.*
-import io.ktor.http.*
 import io.ktor.response.*
 import io.ktor.routing.*
 import no.nav.tms.token.support.idporten.authentication.config.Idporten
 import no.nav.tms.token.support.idporten.authentication.config.RuntimeContext
+import no.nav.tms.token.support.idporten.user.IdportenUserFactory
 
 internal fun Routing.loginApi(runtimeContext: RuntimeContext) {
 
-    val settings = runtimeContext.oauth2ServerSettings
+    val verifier = createVerifier(runtimeContext)
 
-    authenticate(Idporten.authenticatorName) {
-        // This method is empty because the authenticator will redirect any calls to idporten, which will in turn
-        // redirect to 'oath2/callback'. This method exists to differentiate between internal and external redirects
-        get("/oauth2/login") {}
+    get("/login") {
+        val redirectUri = call.redirectUri
 
-        // Users should arrive at this endpoint after a redirect from idporten, which will include a 'code' parameter
-        // This parameter will be used to retrieve the user's token directly from idporten, and will then be provided
-        // to the user as a token. The name of this token is determined when installing authentication.
-        get("/oauth2/callback") {
-            val principal = checkNotNull(call.authentication.principal<OAuthAccessTokenResponse.OAuth2>())
-            when (val decodedJWT = settings.verify(principal, runtimeContext)) {
-                null -> call.respond(HttpStatusCode.InternalServerError, "Fant ikke ${Idporten.responseToken} i tokenrespons")
-                else -> {
-                    call.setTokenCookie(decodedJWT.token, runtimeContext)
-                    call.response.cookies.appendExpired(Idporten.postLoginRedirectCookie, path = "/${runtimeContext.contextPath}")
-                    call.respondRedirect(call.request.cookies[Idporten.postLoginRedirectCookie] ?: runtimeContext.postLoginRedirectUri)
-                }
-            }
+        if (redirectUri != null) {
+            call.response.cookies.append(Idporten.postLoginRedirectCookie, redirectUri, path = "/${runtimeContext.contextPath}")
+        }
+
+        call.respondRedirect(getLoginUrl(runtimeContext.contextPath))
+    }
+
+    get("/login/status") {
+        val idToken = call.validIdTokenOrNull(runtimeContext.tokenCookieName, verifier)
+
+        if (idToken == null) {
+            call.respond(LoginStatus.unAuthenticated())
+        } else {
+            call.respond(LoginStatus.authenticated(IdportenUserFactory.extractLoginLevel(idToken)))
         }
     }
 }
 
-private fun ApplicationCall.setTokenCookie(token: String, runtimeContext: RuntimeContext) {
-    response.cookies.append(
-            name = runtimeContext.tokenCookieName,
-            value = token,
-            secure = runtimeContext.secureCookie,
-            httpOnly = true,
-            path = "/${runtimeContext.contextPath}"
-    )
+private fun ApplicationCall.validIdTokenOrNull(tokenCookieName: String, verifier: TokenVerifier): DecodedJWT? {
+
+    val idToken = request.cookies[tokenCookieName]
+
+    return if (idToken != null) {
+        try {
+            verifier.verify(idToken)
+        } catch (e: Throwable) {
+            null
+        }
+    } else {
+        null
+    }
 }
 
-private fun OAuthServerSettings.OAuth2ServerSettings.verify(tokenResponse: OAuthAccessTokenResponse.OAuth2?, runtimeContext: RuntimeContext): DecodedJWT? =
-tokenResponse?.idToken(Idporten.responseToken)?.let {
-    runtimeContext.jwkProvider[JWT.decode(it).keyId].idTokenVerifier(
-            clientId,
-            runtimeContext.metadata.issuer
-    ).verify(it)
+private fun createVerifier(runtimeContext: RuntimeContext) = TokenVerifier(
+        jwkProvider = runtimeContext.jwkProvider,
+        clientId = runtimeContext.environment.idportenClientId,
+        issuer = runtimeContext.metadata.issuer
+)
+
+private fun getLoginUrl(contextPath: String): String {
+    return if (contextPath.isBlank()) {
+        "/oauth2/login"
+    } else {
+        "/$contextPath/oauth2/login"
+    }
 }
 
-private fun OAuthAccessTokenResponse.OAuth2.idToken(tokenCookieName: String): String? = extraParameters[tokenCookieName]
+private val ApplicationCall.redirectUri: String? get() = request.queryParameters["redirect_uri"]

--- a/token-support-idporten/src/main/kotlin/no/nav/tms/token/support/idporten/authentication/oauth2LoginApi.kt
+++ b/token-support-idporten/src/main/kotlin/no/nav/tms/token/support/idporten/authentication/oauth2LoginApi.kt
@@ -1,0 +1,54 @@
+package no.nav.tms.token.support.idporten.authentication
+
+import com.auth0.jwt.JWT
+import com.auth0.jwt.interfaces.DecodedJWT
+import io.ktor.application.*
+import io.ktor.auth.*
+import io.ktor.http.*
+import io.ktor.response.*
+import io.ktor.routing.*
+import no.nav.tms.token.support.idporten.authentication.config.Idporten
+import no.nav.tms.token.support.idporten.authentication.config.RuntimeContext
+
+internal fun Routing.oauth2LoginApi(runtimeContext: RuntimeContext) {
+
+    val settings = runtimeContext.oauth2ServerSettings
+
+    authenticate(Idporten.authenticatorName) {
+        // This method is empty because the authenticator will redirect any calls to idporten, which will in turn
+        // redirect to 'oath2/callback'. This method exists to differentiate between internal and external redirects
+        get("/oauth2/login") {}
+
+        // Users should arrive at this endpoint after a redirect from idporten, which will include a 'code' parameter
+        // This parameter will be used to retrieve the user's token directly from idporten, and will then be provided
+        // to the user as a token. The name of this token is determined when installing authentication.
+        get("/oauth2/callback") {
+            val principal = checkNotNull(call.authentication.principal<OAuthAccessTokenResponse.OAuth2>())
+            when (val decodedJWT = settings.verify(principal, runtimeContext)) {
+                null -> call.respond(HttpStatusCode.InternalServerError, "Fant ikke ${Idporten.responseToken} i tokenrespons")
+                else -> {
+                    call.setTokenCookie(decodedJWT.token, runtimeContext)
+                    call.response.cookies.appendExpired(Idporten.postLoginRedirectCookie, path = "/${runtimeContext.contextPath}")
+                    call.respondRedirect(call.request.cookies[Idporten.postLoginRedirectCookie] ?: runtimeContext.postLoginRedirectUri)
+                }
+            }
+        }
+    }
+}
+
+private fun ApplicationCall.setTokenCookie(token: String, runtimeContext: RuntimeContext) {
+    response.cookies.append(
+            name = runtimeContext.tokenCookieName,
+            value = token,
+            secure = runtimeContext.secureCookie,
+            httpOnly = true,
+            path = "/${runtimeContext.contextPath}"
+    )
+}
+
+private fun OAuthServerSettings.OAuth2ServerSettings.verify(tokenResponse: OAuthAccessTokenResponse.OAuth2?, runtimeContext: RuntimeContext): DecodedJWT? =
+tokenResponse?.idToken(Idporten.responseToken)?.let {
+    TokenVerifier(runtimeContext.jwkProvider, clientId, runtimeContext.metadata.issuer).verify(it)
+}
+
+private fun OAuthAccessTokenResponse.OAuth2.idToken(tokenCookieName: String): String? = extraParameters[tokenCookieName]

--- a/token-support-idporten/src/main/kotlin/no/nav/tms/token/support/idporten/authentication/verifier.kt
+++ b/token-support-idporten/src/main/kotlin/no/nav/tms/token/support/idporten/authentication/verifier.kt
@@ -7,7 +7,7 @@ import com.auth0.jwt.algorithms.Algorithm
 import com.auth0.jwt.interfaces.JWTVerifier
 import java.security.interfaces.RSAPublicKey
 
-internal fun createVerifier(jwkProvider: JwkProvider, clientId: String, issuer: String): (String) -> JWTVerifier? = {
+internal fun createVerifier(jwkProvider: JwkProvider, clientId: String, issuer: String): (String) -> JWTVerifier = {
     jwkProvider.get(JWT.decode(it).keyId).idTokenVerifier(
             clientId,
             issuer

--- a/token-support-idporten/src/main/kotlin/no/nav/tms/token/support/idporten/config.kt
+++ b/token-support-idporten/src/main/kotlin/no/nav/tms/token/support/idporten/config.kt
@@ -11,6 +11,7 @@ import no.nav.tms.token.support.idporten.authentication.AuthConfiguration
 import no.nav.tms.token.support.idporten.authentication.config.Idporten
 import no.nav.tms.token.support.idporten.authentication.config.RuntimeContext
 import no.nav.tms.token.support.idporten.authentication.idToken
+import no.nav.tms.token.support.idporten.authentication.loginApi
 import no.nav.tms.token.support.idporten.authentication.oauth2LoginApi
 import no.nav.tms.token.support.idporten.authentication.logout.LogoutAuthenticator
 import no.nav.tms.token.support.idporten.authentication.logout.LogoutConfig
@@ -74,8 +75,9 @@ fun Application.installIdPortenAuth(configure: IdportenAuthenticationConfig.() -
 
     }
 
-    // Register endpoints 'oauth2/login',  'oath2/callback', '/logout', and /oauth2/logout
+    // Register endpoints '/login', '/login/status', 'oauth2/login', 'oath2/callback', '/logout', and /oauth2/logout
     routing {
+        loginApi(runtimeContext)
         oauth2LoginApi(runtimeContext)
         logoutApi(runtimeContext)
     }

--- a/token-support-idporten/src/main/kotlin/no/nav/tms/token/support/idporten/user/IdportenUserFactory.kt
+++ b/token-support-idporten/src/main/kotlin/no/nav/tms/token/support/idporten/user/IdportenUserFactory.kt
@@ -31,7 +31,7 @@ object IdportenUserFactory {
         return IdportenUser(ident, loginLevel, expirationTime, token)
     }
 
-    private fun extractLoginLevel(token: DecodedJWT): Int {
+    internal fun extractLoginLevel(token: DecodedJWT): Int {
 
         return when (token.getClaim("acr").asString()) {
             "Level3" -> 3


### PR DESCRIPTION
La til mulighet for å velge samme flyt som vi er vandt med fra dittnav. 

Det vil si at frontended har mulighet for å spørre api-et om bruker er logget inn eller ikke, og kan så sende brukere til et endepunkt som er dedikert login. Beskyttede vil som default svare med 401 i stedet for en redirect. Dette kan konfigureres ved oppsett av feature. 