### PR TITLE
Endre caching av token vekslet mot tokendings, slik at de caches per bruker per client, og ikke bare per bruker.

### DIFF
--- a/token-support-tokendings-exchange/src/main/kotlin/no/nav/tms/token/support/tokendings/exchange/config/cache/AccessTokenKey.kt
+++ b/token-support-tokendings-exchange/src/main/kotlin/no/nav/tms/token/support/tokendings/exchange/config/cache/AccessTokenKey.kt
@@ -1,0 +1,6 @@
+package no.nav.tms.token.support.tokendings.exchange.config.cache
+
+internal data class AccessTokenKey(
+        val subject: String,
+        val targetApp: String
+)

--- a/token-support-tokendings-exchange/src/main/kotlin/no/nav/tms/token/support/tokendings/exchange/config/cache/CacheBuilder.kt
+++ b/token-support-tokendings-exchange/src/main/kotlin/no/nav/tms/token/support/tokendings/exchange/config/cache/CacheBuilder.kt
@@ -6,24 +6,24 @@ import com.github.benmanes.caffeine.cache.Expiry
 import java.util.concurrent.TimeUnit
 
 internal object CacheBuilder {
-    fun buildCache(maxEntries: Long, expiryMarginSeconds: Int): Cache<String, AccessTokenEntry> {
+    fun buildCache(maxEntries: Long, expiryMarginSeconds: Int): Cache<AccessTokenKey, AccessTokenEntry> {
         return Caffeine.newBuilder()
                 .expireAfter(createExpiryPolicy(expiryMarginSeconds))
                 .maximumSize(maxEntries)
                 .build()
     }
 
-    private fun createExpiryPolicy(expiryMarginSeconds: Int) = object : Expiry<String, AccessTokenEntry> {
-        override fun expireAfterCreate(key: String, response: AccessTokenEntry, currentTime: Long): Long {
+    private fun createExpiryPolicy(expiryMarginSeconds: Int) = object : Expiry<AccessTokenKey, AccessTokenEntry> {
+        override fun expireAfterCreate(key: AccessTokenKey, response: AccessTokenEntry, currentTime: Long): Long {
             return TimeUnit.SECONDS.toNanos(response.expiresInSeconds - expiryMarginSeconds)
         }
 
-        override fun expireAfterUpdate(key: String,
+        override fun expireAfterUpdate(key: AccessTokenKey,
                                        value: AccessTokenEntry,
                                        currentTime: Long,
                                        currentDuration: Long): Long = currentDuration
 
-        override fun expireAfterRead(key: String,
+        override fun expireAfterRead(key: AccessTokenKey,
                                      value: AccessTokenEntry,
                                      currentTime: Long,
                                      currentDuration: Long): Long = currentDuration

--- a/token-support-tokendings-exchange/src/main/kotlin/no/nav/tms/token/support/tokendings/exchange/service/tokendingsServiceImpl.kt
+++ b/token-support-tokendings-exchange/src/main/kotlin/no/nav/tms/token/support/tokendings/exchange/service/tokendingsServiceImpl.kt
@@ -5,6 +5,7 @@ import com.nimbusds.jose.jwk.RSAKey
 import kotlinx.coroutines.runBlocking
 import no.nav.tms.token.support.tokendings.exchange.TokendingsService
 import no.nav.tms.token.support.tokendings.exchange.config.cache.AccessTokenEntry
+import no.nav.tms.token.support.tokendings.exchange.config.cache.AccessTokenKey
 import no.nav.tms.token.support.tokendings.exchange.config.cache.CacheBuilder
 import no.nav.tms.token.support.tokendings.exchange.consumer.TokendingsConsumer
 import no.nav.tms.token.support.tokendings.exchange.service.ClientAssertion.createSignedAssertion
@@ -41,7 +42,9 @@ class CachingTokendingsService internal constructor(
     override suspend fun exchangeToken(token: String, targetApp: String): String {
         val subject = TokenStringUtil.extractSubject(token)
 
-        return cache.get(subject) {
+        val cacheKey = AccessTokenKey(subject, targetApp)
+
+        return cache.get(cacheKey) {
             runBlocking {
                 performTokenExchange(token, targetApp)
             }


### PR DESCRIPTION
Endre cache key for tokendings-cache, slik at det er et kompositt av subject fra idporten-token, òg clientId for destinasjonsapp. 

Dette fikser tilfellet der et token vekslet for én app feilaktig ble gjenbrukt for en annen app hvis det fantes i cachen.