### PR TITLE
Enable webproxy for idporten

### DIFF
--- a/token-support-idporten/README.md
+++ b/token-support-idporten/README.md
@@ -16,15 +16,16 @@ For å kunne autentisere et endepunkt må man først installere autentikatoren.
 
 Her er det en rekke variabler:
 
-`tokenCookieName`: (Required) Navn på token-cookien som settes i browser etter bruker har logget inn.
-`postLogoutRedirectUri`: (Required) Bestemmer hvor bruker sendes etter de har logget ut. Denne må samsvare med nais-yaml.
-`postLoginRedirectUri`: (Optional) Url der bruker havner etter login dersom vi ikke finner en "redirect_uri" cookie. Default ""
-`setAsDefault`: (Optional) Setter denne autentikatoren som default. Default 'false'
-`secureCookie`: (Optional) Setter token-cookie som secure, slik at den kun sendes med https-kall. Bør kun skrus av ved lokal kjøring. Default 'true'
-`alwaysRedirectToLogin`: (Optional) Bestemmer om beskyttede endepunkt kan sende bruker til ID-porten, eller om de kun svarer med status 401. Default 'false'
-`securityLevel`: (Optional) Setter minimum sikkerhetsnivå for alle innlogginger. Default 'NOT_SPECIFIED'
-`tokenRefreshEnabled`: (Optional) Bestemmer om biblioteket automatisk skal fornye brukers token når det nærmer seg å løpe ut. Default 'false'
-`tokenRefreshMarginPercentage`: (Optional) Bestemmer hvor nær et token skal være å løpe ut før det fornyes. Gis som en prosentverdi av tokenets totale levetid. Default '25'
+- `tokenCookieName`: (Required) Navn på token-cookien som settes i browser etter bruker har logget inn.
+- `postLogoutRedirectUri`: (Required) Bestemmer hvor bruker sendes etter de har logget ut. Denne må samsvare med nais-yaml.
+- `postLoginRedirectUri`: (Optional) Url der bruker havner etter login dersom vi ikke finner en "redirect_uri" cookie. Default ""
+- `setAsDefault`: (Optional) Setter denne autentikatoren som default. Default 'false'
+- `secureCookie`: (Optional) Setter token-cookie som secure, slik at den kun sendes med https-kall. Bør kun skrus av ved lokal kjøring. Default 'true'
+- `alwaysRedirectToLogin`: (Optional) Bestemmer om beskyttede endepunkt kan sende bruker til ID-porten, eller om de kun svarer med status 401. Default 'false'
+- `securityLevel`: (Optional) Setter minimum sikkerhetsnivå for alle innlogginger. Default 'NOT_SPECIFIED'
+- `tokenRefreshEnabled`: (Optional) Bestemmer om biblioteket automatisk skal fornye brukers token når det nærmer seg å løpe ut. Default 'false'
+- `tokenRefreshMarginPercentage`: (Optional) Bestemmer hvor nær et token skal være å løpe ut før det fornyes. Gis som en prosentverdi av tokenets totale levetid. Default '25'
+- `enableDefaultProxy`: (Optional) Bestemmer hvorvidt system-default proxy skal brukes ved kall mot andre tjenester. Nødvendig for on-prem apper med webproxy.
  
 Eksempel på konfigurasjon:
 
@@ -41,6 +42,7 @@ fun Application.mainModule() {
         securityLevel = SecurityLevel.LEVEL_3
         tokenRefreshEnabled = true
         tokenRefreshMarginPercentage = 20
+        enableDefaultProxy = false
     }
 }
 ```
@@ -60,6 +62,7 @@ fun Application.mainModule() {
         securityLevel = SecurityLevel.LEVEL_3
         tokenRefreshEnabled = true
         tokenRefreshMarginPercentage = 20
+        enableDefaultProxy = false
     }
     
     routing {

--- a/token-support-idporten/src/main/kotlin/no/nav/tms/token/support/idporten/IdPortenInstaller.kt
+++ b/token-support-idporten/src/main/kotlin/no/nav/tms/token/support/idporten/IdPortenInstaller.kt
@@ -33,7 +33,8 @@ object IdPortenInstaller {
                 secureCookie = config.secureCookie,
                 postLogoutRedirectUri = config.postLogoutRedirectUri,
                 securityLevel = config.securityLevel,
-                tokenRefreshMarginPercentage = config.tokenRefreshMarginPercentage
+                tokenRefreshMarginPercentage = config.tokenRefreshMarginPercentage,
+                enableDefaultProxy = config.enableDefaultProxy
         )
 
         installXForwardedHeaderSupportIfMissing()

--- a/token-support-idporten/src/main/kotlin/no/nav/tms/token/support/idporten/IdPortenInstaller.kt
+++ b/token-support-idporten/src/main/kotlin/no/nav/tms/token/support/idporten/IdPortenInstaller.kt
@@ -91,7 +91,7 @@ object IdPortenInstaller {
         // Register authenticator which redirects user to idporten to perform login. This should only apply to endpoints
         // 'oath2/login' and 'oath2/callback'
         oauth(Idporten.authenticatorName) {
-            client = HttpClient(Apache)
+            client = runtimeContext.httpClient
             providerLookup = { runtimeContext.oauth2ServerSettings }
             urlProvider = { runtimeContext.environment.idportenRedirectUri }
         }

--- a/token-support-idporten/src/main/kotlin/no/nav/tms/token/support/idporten/authentication/config/HttpClientBuilder.kt
+++ b/token-support-idporten/src/main/kotlin/no/nav/tms/token/support/idporten/authentication/config/HttpClientBuilder.kt
@@ -5,14 +5,20 @@ import io.ktor.client.engine.apache.*
 import io.ktor.client.features.*
 import io.ktor.client.features.json.*
 import io.ktor.client.features.json.serializer.*
+import org.apache.http.impl.conn.SystemDefaultRoutePlanner
+import java.net.ProxySelector
 
 internal object HttpClientBuilder {
-    internal fun buildHttpClient(): HttpClient {
+    internal fun buildHttpClient(enableDefaultProxy: Boolean): HttpClient {
         return HttpClient(Apache) {
             install(JsonFeature) {
                 serializer = buildJsonSerializer()
             }
             install(HttpTimeout)
+
+            if (enableDefaultProxy) {
+                enableSystemDefaultProxy()
+            }
         }
     }
 
@@ -22,5 +28,10 @@ internal object HttpClientBuilder {
             }
     )
 
+    private fun HttpClientConfig<ApacheEngineConfig>.enableSystemDefaultProxy() {
+        engine {
+            customizeClient { setRoutePlanner(SystemDefaultRoutePlanner(ProxySelector.getDefault())) }
+        }
+    }
 }
 

--- a/token-support-idporten/src/main/kotlin/no/nav/tms/token/support/idporten/authentication/config/RuntimeContext.kt
+++ b/token-support-idporten/src/main/kotlin/no/nav/tms/token/support/idporten/authentication/config/RuntimeContext.kt
@@ -26,11 +26,12 @@ internal class RuntimeContext(
         val secureCookie: Boolean,
         val postLogoutRedirectUri: String,
         val securityLevel: SecurityLevel,
-        val tokenRefreshMarginPercentage: Int
+        val tokenRefreshMarginPercentage: Int,
+        enableDefaultProxy: Boolean
 ) {
     val environment = Environment()
 
-    private val httpClient = buildHttpClient()
+    private val httpClient = buildHttpClient(enableDefaultProxy)
     val metadata = fetchMetadata(httpClient, environment.idportenWellKnownUrl)
 
     private val clientAssertionService = ClientAssertionService(environment.idportenClientJwk, environment.idportenClientId, metadata.issuer)

--- a/token-support-idporten/src/main/kotlin/no/nav/tms/token/support/idporten/authentication/config/RuntimeContext.kt
+++ b/token-support-idporten/src/main/kotlin/no/nav/tms/token/support/idporten/authentication/config/RuntimeContext.kt
@@ -31,7 +31,7 @@ internal class RuntimeContext(
 ) {
     val environment = Environment()
 
-    private val httpClient = buildHttpClient(enableDefaultProxy)
+    val httpClient = buildHttpClient(enableDefaultProxy)
     val metadata = fetchMetadata(httpClient, environment.idportenWellKnownUrl)
 
     private val clientAssertionService = ClientAssertionService(environment.idportenClientJwk, environment.idportenClientId, metadata.issuer)

--- a/token-support-idporten/src/main/kotlin/no/nav/tms/token/support/idporten/config.kt
+++ b/token-support-idporten/src/main/kotlin/no/nav/tms/token/support/idporten/config.kt
@@ -26,6 +26,7 @@ class IdportenAuthenticationConfig {
     var securityLevel: SecurityLevel = NOT_SPECIFIED
     var tokenRefreshEnabled: Boolean = false
     var tokenRefreshMarginPercentage: Int = 25
+    var enableDefaultProxy: Boolean = false
 
     val refreshTokenCookieName get() = "${tokenCookieName}_refresh_token"
     val idTokenCookieName get() = "${tokenCookieName}_id_token"

--- a/token-support-idporten/src/test/kotlin/no/nav/tms/token/support/idporten/IdportenAuthIT.kt
+++ b/token-support-idporten/src/test/kotlin/no/nav/tms/token/support/idporten/IdportenAuthIT.kt
@@ -29,7 +29,7 @@ internal class IdportenAuthIT {
     @BeforeEach
     fun setupMock() {
         mockkObject(HttpClientBuilder)
-        every { HttpClientBuilder.buildHttpClient() } returns mockedClient
+        every { HttpClientBuilder.buildHttpClient(any()) } returns mockedClient
     }
 
     @AfterEach


### PR DESCRIPTION
Legger til mulighet for å bruke idporten biblioteket on-prem ved å kunne toggle bruk av default proxy.