### PR TITLE
Logger feil ved refresh av token som debug i stedet for warn. Logger også exception.

### DIFF
--- a/token-support-idporten/src/main/kotlin/no/nav/tms/token/support/idporten/authentication/accessToken.kt
+++ b/token-support-idporten/src/main/kotlin/no/nav/tms/token/support/idporten/authentication/accessToken.kt
@@ -129,7 +129,7 @@ private suspend fun ApplicationCall.refreshAccessTokenCookie(refreshToken: Strin
 
         JWT.decode(result.accessToken)
     } catch (e: Exception) {
-        log.warn("Was unable to refresh access token.")
+        log.debug("Was unable to refresh access token.", e)
         null
     }
 }


### PR DESCRIPTION
Gjøres for å redusere uønsket støy i andre prosjekt, samtidig som vi gir mer info der det ønskes.