### PR TITLE
Legger opp til å sende azure/tokenx tokens i egen header.

### DIFF
--- a/token-support-azure-exchange/src/main/kotlin/no/nav/tms/token/support/azure/exchange/service/AzureHeader.kt
+++ b/token-support-azure-exchange/src/main/kotlin/no/nav/tms/token/support/azure/exchange/service/AzureHeader.kt
@@ -1,0 +1,5 @@
+package no.nav.tms.token.support.azure.exchange.service
+
+object AzureHeader {
+    const val Authorization = "azure-authorization"
+}

--- a/token-support-azure-validation/src/main/kotlin/no/nav/tms/token/support/azure/validation/config.kt
+++ b/token-support-azure-validation/src/main/kotlin/no/nav/tms/token/support/azure/validation/config.kt
@@ -19,3 +19,7 @@ class AzureAuthenticatorConfig {
 object AzureAuthenticator {
     const val name = "azure_bearer_access_token"
 }
+
+object AzureHeader {
+    const val Authorization = "azure-authorization"
+}

--- a/token-support-tokendings-exchange/src/main/kotlin/no/nav/tms/token/support/tokendings/exchange/TokenXHeader.kt
+++ b/token-support-tokendings-exchange/src/main/kotlin/no/nav/tms/token/support/tokendings/exchange/TokenXHeader.kt
@@ -1,0 +1,5 @@
+package no.nav.tms.token.support.tokendings.exchange
+
+object TokenXHeader {
+    const val Authorization = "token-x-authorization"
+}

--- a/token-support-tokenx-validation/src/main/kotlin/no/nav/tms/token/support/tokenx/validation/config.kt
+++ b/token-support-tokenx-validation/src/main/kotlin/no/nav/tms/token/support/tokenx/validation/config.kt
@@ -2,6 +2,7 @@ package no.nav.tms.token.support.tokenx.validation
 
 import io.ktor.application.*
 import io.ktor.auth.*
+import io.ktor.http.*
 import no.nav.tms.token.support.tokenx.validation.config.RuntimeContext
 import no.nav.tms.token.support.tokenx.validation.tokendings.tokenXAccessToken
 
@@ -33,4 +34,8 @@ class TokenXAuthenticatorConfig {
 
 object TokenXAuthenticator {
     const val name = "tokenx_bearer_access_token"
+}
+
+object TokenXHeader {
+    const val Authorization = "token-x-authorization"
 }


### PR DESCRIPTION
La tokenx og azure autentikatorene prioritere egne headere, slik at vi kan unngå at idporten-sidecar overskriver tokenet vårt.