### PR TITLE
Fjerner validering av client_id når tokens hentes fra idporten-sidecar.

### DIFF
--- a/token-support-idporten-sidecar/README.md
+++ b/token-support-idporten-sidecar/README.md
@@ -104,10 +104,9 @@ authenticate(IdPortenCookieAuthenticator.name) {
 
 ## Bruk av biblioteket ved lokal kjøring 
 
-Dette biblioteket forventer at følgende miljøvariabler er satt:
+Dette biblioteket forventer at følgende miljøvariabel er satt:
 
 - IDPORTEN_WELL_KNOWN_URL
-- IDPORTEN_CLIENT_ID
 
 Når nais-yaml er konfigurert riktig settes disse av plattformen ved kjøring i miljø. Ved lokal kjøring må disse også være satt. 
 

--- a/token-support-idporten-sidecar/src/main/kotlin/no/nav/tms/token/support/idporten/sidecar/authentication/AuthConfiguration.kt
+++ b/token-support-idporten-sidecar/src/main/kotlin/no/nav/tms/token/support/idporten/sidecar/authentication/AuthConfiguration.kt
@@ -4,7 +4,6 @@ import com.auth0.jwk.JwkProvider
 
 internal class AuthConfiguration(
         jwkProvider: JwkProvider,
-        clientId: String,
         issuer: String,
         loginLevel: Int,
         val fallbackTokenCookieEnabled: Boolean,
@@ -12,7 +11,6 @@ internal class AuthConfiguration(
 ) {
         val tokenVerifier = TokenVerifierBuilder.buildTokenVerifier(
                 jwkProvider = jwkProvider,
-                clientId = clientId,
                 issuer = issuer,
                 loginLevel = loginLevel
         )

--- a/token-support-idporten-sidecar/src/main/kotlin/no/nav/tms/token/support/idporten/sidecar/authentication/OauthServerConfigurationMetadata.kt
+++ b/token-support-idporten-sidecar/src/main/kotlin/no/nav/tms/token/support/idporten/sidecar/authentication/OauthServerConfigurationMetadata.kt
@@ -7,6 +7,5 @@ import kotlinx.serialization.Serializable
 @Serializable
 internal data class OauthServerConfigurationMetadata(
         @SerialName("issuer") val issuer: String,
-        @SerialName("token_endpoint") val tokenEndpoint: String,
         @SerialName("jwks_uri") val jwksUri: String,
 )

--- a/token-support-idporten-sidecar/src/main/kotlin/no/nav/tms/token/support/idporten/sidecar/authentication/TokenVerifier.kt
+++ b/token-support-idporten-sidecar/src/main/kotlin/no/nav/tms/token/support/idporten/sidecar/authentication/TokenVerifier.kt
@@ -10,7 +10,6 @@ import java.security.interfaces.RSAPublicKey
 
 internal class TokenVerifier(
         private val jwkProvider: JwkProvider,
-        private val clientId: String,
         private val issuer: String,
         private val minLoginLevel: Int
 ) {
@@ -20,7 +19,7 @@ internal class TokenVerifier(
     fun verifyAccessToken(accessToken: String): DecodedJWT {
         val decodedToken = JWT.decode(accessToken).keyId
             .let { kid -> jwkProvider.get(kid) }
-            .run { accessTokenVerifier(clientId, issuer) }
+            .run { accessTokenVerifier(issuer) }
             .run { verify(accessToken) }
 
         verifyLoginLevel(decodedToken)
@@ -28,9 +27,8 @@ internal class TokenVerifier(
         return decodedToken
     }
 
-    private fun Jwk.accessTokenVerifier(clientId: String, issuer: String): JWTVerifier =
+    private fun Jwk.accessTokenVerifier(issuer: String): JWTVerifier =
             JWT.require(this.RSA256())
-                .withClaim("client_id", clientId)
                 .withIssuer(issuer)
                 .build()
 

--- a/token-support-idporten-sidecar/src/main/kotlin/no/nav/tms/token/support/idporten/sidecar/authentication/TokenVerifierBuilder.kt
+++ b/token-support-idporten-sidecar/src/main/kotlin/no/nav/tms/token/support/idporten/sidecar/authentication/TokenVerifierBuilder.kt
@@ -6,12 +6,10 @@ import com.auth0.jwk.JwkProvider
 internal object TokenVerifierBuilder {
     fun buildTokenVerifier(
         jwkProvider: JwkProvider,
-        clientId: String,
         issuer: String,
         loginLevel: Int,
     ) = TokenVerifier(
         jwkProvider = jwkProvider,
-        clientId = clientId,
         issuer = issuer,
         minLoginLevel = loginLevel
     )

--- a/token-support-idporten-sidecar/src/main/kotlin/no/nav/tms/token/support/idporten/sidecar/authentication/config/Environment.kt
+++ b/token-support-idporten-sidecar/src/main/kotlin/no/nav/tms/token/support/idporten/sidecar/authentication/config/Environment.kt
@@ -1,8 +1,7 @@
 package no.nav.tms.token.support.idporten.sidecar.authentication.config
 
 internal class Environment (
-        val idportenWellKnownUrl: String = getIdportenEnvVar("IDPORTEN_WELL_KNOWN_URL"),
-        val idportenClientId: String = getIdportenEnvVar("IDPORTEN_CLIENT_ID")
+        val idportenWellKnownUrl: String = getIdportenEnvVar("IDPORTEN_WELL_KNOWN_URL")
 )
 
 private fun getIdportenEnvVar(varName: String): String {

--- a/token-support-idporten-sidecar/src/main/kotlin/no/nav/tms/token/support/idporten/sidecar/authentication/config/RuntimeContext.kt
+++ b/token-support-idporten-sidecar/src/main/kotlin/no/nav/tms/token/support/idporten/sidecar/authentication/config/RuntimeContext.kt
@@ -28,7 +28,6 @@ internal class RuntimeContext(
 
     val authConfiguration = AuthConfiguration(
         jwkProvider = jwkProvider,
-        clientId = environment.idportenClientId,
         issuer = metadata.issuer,
         fallbackTokenCookieEnabled = fallbackTokenCookieEnabled,
         fallbackTokenCookieName = fallbackTokenCookieName,

--- a/token-support-idporten-sidecar/src/test/kotlin/no/nav/tms/token/support/idporten/sidecar/IdportenAuthIT.kt
+++ b/token-support-idporten-sidecar/src/test/kotlin/no/nav/tms/token/support/idporten/sidecar/IdportenAuthIT.kt
@@ -35,7 +35,7 @@ internal class IdportenAuthIT {
     fun setupMock() {
         mockkObject(TokenVerifierBuilder)
         mockkObject(HttpClientBuilder)
-        every { TokenVerifierBuilder.buildTokenVerifier(any(), any(), any(), any()) } returns verifier
+        every { TokenVerifierBuilder.buildTokenVerifier(any(), any(), any()) } returns verifier
         every { HttpClientBuilder.buildHttpClient(any()) } returns mockedClient
     }
 

--- a/token-support-idporten-sidecar/src/test/kotlin/no/nav/tms/token/support/idporten/sidecar/JwtBuilder.kt
+++ b/token-support-idporten-sidecar/src/test/kotlin/no/nav/tms/token/support/idporten/sidecar/JwtBuilder.kt
@@ -11,12 +11,11 @@ import java.util.*
 
 object JwtBuilder {
 
-    fun generateJwtString(issueTime: Date, expiryTime: Date, issuer: String, clientId: String, loginLevel: String, rsaKey: RSAKey): String {
+    fun generateJwtString(issueTime: Date, expiryTime: Date, issuer: String, loginLevel: String, rsaKey: RSAKey): String {
         return JWTClaimsSet.Builder()
             .issuer(issuer)
             .issueTime(issueTime)
             .expirationTime(expiryTime)
-            .claim("client_id", clientId)
             .claim("acr", loginLevel)
             .jwtID(UUID.randomUUID().toString())
             .build()

--- a/token-support-idporten-sidecar/src/test/kotlin/no/nav/tms/token/support/idporten/sidecar/authentication/TokenVerifierTest.kt
+++ b/token-support-idporten-sidecar/src/test/kotlin/no/nav/tms/token/support/idporten/sidecar/authentication/TokenVerifierTest.kt
@@ -20,7 +20,6 @@ import java.util.*
 
 internal class TokenVerifierTest {
     private val jwk = JwkBuilder.generateJwk()
-    private val clientId = "clientId"
     private val issuer = "issuer"
     private val level4 = "Level4"
 
@@ -38,7 +37,6 @@ internal class TokenVerifierTest {
     fun `Should accept valid token`() {
         val verifier = TokenVerifier(
             jwkProvider = jwkProvider,
-            clientId = clientId,
             issuer = issuer,
             minLoginLevel = 4
         )
@@ -47,7 +45,6 @@ internal class TokenVerifierTest {
             issueTime = now.toDate(),
             expiryTime = hourFromNow.toDate(),
             issuer = issuer,
-            clientId = clientId,
             loginLevel = level4,
             rsaKey = jwk
         )
@@ -60,36 +57,9 @@ internal class TokenVerifierTest {
     }
 
     @Test
-    fun `Should not accept token with invalid client`() {
-        val verifier = TokenVerifier(
-            jwkProvider = jwkProvider,
-            clientId = clientId,
-            issuer = issuer,
-            minLoginLevel = 4
-        )
-
-
-        val token = JwtBuilder.generateJwtString(
-            issueTime = now.toDate(),
-            expiryTime = hourFromNow.toDate(),
-            issuer = issuer,
-            clientId = "invalid",
-            loginLevel = level4,
-            rsaKey = jwk
-        )
-
-        every { jwkProvider.get(any()) } returns jwk.toJwk()
-
-        invoking {
-            verifier.verifyAccessToken(token)
-        } `should throw` Exception::class
-    }
-
-    @Test
     fun `Should not accept token with invalid issuer`() {
         val verifier = TokenVerifier(
             jwkProvider = jwkProvider,
-            clientId = clientId,
             issuer = issuer,
             minLoginLevel = 4
         )
@@ -99,7 +69,6 @@ internal class TokenVerifierTest {
             issueTime = now.toDate(),
             expiryTime = hourFromNow.toDate(),
             issuer = "invalid",
-            clientId = clientId,
             loginLevel = level4,
             rsaKey = jwk
         )
@@ -115,7 +84,6 @@ internal class TokenVerifierTest {
     fun `Should not accept expired token`() {
         val verifier = TokenVerifier(
             jwkProvider = jwkProvider,
-            clientId = clientId,
             issuer = issuer,
             minLoginLevel = 4
         )
@@ -125,7 +93,6 @@ internal class TokenVerifierTest {
             issueTime = now.minus(2, HOURS).toDate(),
             expiryTime = now.minus(1, HOURS).toDate(),
             issuer = issuer,
-            clientId = clientId,
             loginLevel = level4,
             rsaKey = jwk
         )
@@ -141,7 +108,6 @@ internal class TokenVerifierTest {
     fun `Should not accept token with too low login level`() {
         val verifier = TokenVerifier(
             jwkProvider = jwkProvider,
-            clientId = clientId,
             issuer = issuer,
             minLoginLevel = 4
         )
@@ -151,7 +117,6 @@ internal class TokenVerifierTest {
             issueTime = now.toDate(),
             expiryTime = hourFromNow.toDate(),
             issuer = issuer,
-            clientId = clientId,
             loginLevel = "Level3",
             rsaKey = jwk
         )

--- a/token-support-idporten-sidecar/src/test/kotlin/no/nav/tms/token/support/idporten/sidecar/mockedClient.kt
+++ b/token-support-idporten-sidecar/src/test/kotlin/no/nav/tms/token/support/idporten/sidecar/mockedClient.kt
@@ -37,7 +37,6 @@ val mockedClient = HttpClient(MockEngine) {
 
 internal val idportenMetadata = OauthServerConfigurationMetadata(
         issuer = "http://mocked-issuer/provider",
-        tokenEndpoint = "http://mocked-issuer/token",
         jwksUri = "http://mocked-issuer/jwks",
 )
 


### PR DESCRIPTION
Fjerner sjekk mot `client_id` når vi validerer tokens i idporten-sidecar modulen.

Denne sjekken er ikke nødvendig når tokens holdes i sidecar-containeren, i stedet for at det holdes i brukers browser.

Sjekken forblir i den deprekerte idporten modulen.